### PR TITLE
Add CSS for blockquote for warnings

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -164,9 +164,10 @@ footer.docs {
   width: calc(100% - 280px);
 }
 
-blockquote.warning {
+.warning {
   border-left: 3px solid rgb(228, 167, 2);
-  padding-left: 12px;
+  padding: 15px;
+  margin: 15px 0;
   color: rgb(138, 108, 64);
   background: rgb(252, 248, 228);
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -164,6 +164,13 @@ footer.docs {
   width: calc(100% - 280px);
 }
 
+blockquote.warning {
+  border-left: 3px solid rgb(228, 167, 2);
+  padding-left: 12px;
+  color: rgb(138, 108, 64);
+  background: rgb(252, 248, 228);
+}
+
 @media screen and (max-width: 600px) {
   .heading h1 {
     font-size: 24px;


### PR DESCRIPTION
@azeey

CSS for blockquotes to show up as a yellow warning banner.

Whether it works on the actual website, we'll have to see...

I tested using the ngx-markdown [preview editor](https://stackblitz.com/edit/ngx-markdown) linked from the [official package](https://www.npmjs.com/package/ngx-markdown):

In app.component.ts, there’s already a line for blockquote:
```
> Blockquote to the max`;
```

Add a line before the tick `:
```
<blockquote class="warning">Second blockquote</blockquote>
```

In styles.css, add:
```
blockquote.warning {
  border-left: 3px solid rgb(228, 167, 2);
  padding-left: 12px;
  color: rgb(138, 108, 64);
  background: rgb(252, 248, 228);
}
```

The Second blockquote in the preview panel should change to yellow.