### PR TITLE
Changing doc version goes to corresponding page in new version

### DIFF
--- a/src/app/doc/doc.component.ts
+++ b/src/app/doc/doc.component.ts
@@ -258,7 +258,7 @@ export class DocComponent implements OnInit, AfterViewChecked {
   }
 
   public onVersionChange(newVersion: string): void {
-    this.router.navigate(['/docs', newVersion]);
+    this.router.navigate(['/docs', newVersion, this.page.name]);
   }
 
 


### PR DESCRIPTION
Fix #18

## To test

I used the `docker_dev` branch in both gazebosim-web-frontend and gazebosim-web-backend repos to test it (merge to that branch locally):
```
cd path/to/gazeobsim-web-frontend
docker build . -t gazebosim_web_frontend
cd path/to/gazebosim-web-backend
docker build . -t gazebosim_web_backend
cd path/to/gazeobsim-web-frontend
docker-compose up
```

Navigate to a documentation page that isn't the default `getstarted`. Choose one that looks different between versions! Like these
http://localhost:3000/docs/garden/comparison
http://localhost:3000/docs/garden/install

In the Release drop-down menu on the upper-right, choose a different release.
Now you should land at the corresponding page in the version you chose (as opposed to the default `getstarted` page, which is the previous behavior).

Requesting review from @azeey