### PR TITLE
Support deploying on github pages with `/docs` and `/libs` generated by sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,8 @@
 
 ## Deployment
 
-The `staging` branch in this repository is used to deploy this website to
-https://staging.gazebosim.org. The `production` branch in this repository is
-used to deploy this website to `https://gazebosim.org`.
-
-Github actions will automatically deploy `staging` on push. The `production`
-branch will only deploy when an authorized user approves the deployment on
-the Github Actions UI.
-
-There is no rule about how a release should be made. A person with sufficient
-access can choose between direct commits or pull requests.
-
-### Internal configuration
-
-The application stores connection info in a JSON file, `app_config.json`. The key-value pairs are as follows:
-
-* `AWS_REGION`: the AWS region code, e.g. 'us-west-2'
-* `STARTUP_SIGNUP_TABLE`: the name of the DynamoDB table where the app stores
-signup data (e.g. `my-ddb-table`)
-* `NEW_SIGNUP_TOPIC`: The [ARN](http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) of the SNS topic that the app uses to send notifications (e.g. `arn:aws:sns:us-west-2:123456789012:my-supercool-app`)
+Deployment of this project has moved to the
+[gazebosim/docs](https://github.com/gazebosim/docs) project.
 
 ## Tests
 
@@ -76,3 +59,8 @@ You can access the generated docs in `./doc/index.html`.
 ## Naming conventions
 
 Following the [Angular Style Guide](https://angular.io/guide/styleguide), we use the `gz` preffix for the selector of our Components and Directives.
+
+
+## Acknowledgments
+
+The Angular single page app in this project uses code from https://github.com/rafgraph/spa-github-pages to deploy with Github Pages.

--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
               "src/assets/icons/favicon.ico",
               "src/assets",
               "src/robots.txt",
-              "src/sitemap.xml"
+              "src/sitemap.xml",
+              "src/404.html"
             ],
             "styles": [
               "src/styles.scss",

--- a/src/404.html
+++ b/src/404.html
@@ -23,7 +23,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 0;
+      var pathSegmentsToKeep = 1;
 
       var l = window.location;
       l.replace(

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<!-- Taken from https://github.com/rafgraph/spa-github-pages -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/404.html
+++ b/src/404.html
@@ -6,7 +6,29 @@
     <title>Single Page Apps for GitHub Pages</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages
-      // MIT License
+      //
+      // The MIT License (MIT)
+      //
+      // Copyright (c) 2016 Rafael Pedicini
+      //
+      // Permission is hereby granted, free of charge, to any person obtaining a copy
+      // of this software and associated documentation files (the "Software"), to deal
+      // in the Software without restriction, including without limitation the rights
+      // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      // copies of the Software, and to permit persons to whom the Software is
+      // furnished to do so, subject to the following conditions:
+      //
+      // The above copyright notice and this permission notice shall be included in all
+      // copies or substantial portions of the Software.
+      //
+      // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+      // SOFTWARE.
+      //
       // https://github.com/rafgraph/spa-github-pages
       // This script takes the current url and converts the path and query
       // string into just a query string, and then redirects the browser

--- a/src/404.html
+++ b/src/404.html
@@ -45,7 +45,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 1;
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,11 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AboutComponent } from './about';
-import { DocComponent,
-         DocsResolver } from './doc';
 import { HomeComponent } from './home';
-import { LibComponent } from './lib';
-import { LibsComponent } from './libs';
 import { MaritimeComponent } from './projects/maritime';
 import { NotFoundComponent } from './not-found';
 import { OmniverseComponent } from './projects/omniverse';
@@ -25,42 +21,12 @@ const routes: Routes = [
     component: AboutComponent,
   },
   {
-    path: 'docs',
-    component: DocComponent,
-    resolve: {
-      docsInfo: DocsResolver
-    }
-  },
-  {
-    path: 'docs/:version',
-    component: DocComponent,
-    resolve: {
-      docsInfo: DocsResolver
-    }
-  },
-  {
-    // Gets the page associated with a specific version
-    path: 'docs/:version/:page',
-    component: DocComponent,
-    resolve: {
-      docsInfo: DocsResolver
-    }
-  },
-  {
     path: 'features',
     component: FeaturesComponent,
   },
   {
     path: 'home',
     component: HomeComponent,
-  },
-  {
-    path: 'libs',
-    component: LibsComponent,
-  },
-  {
-    path: 'libs/:lib',
-    component: LibComponent,
   },
   {
     path: 'media',

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,7 +11,7 @@
       <div></div>
       <a routerLink='/features' routerLinkActive='active'>Features</a>
       <a routerLink='/showcase' routerLinkActive='active'>Showcase</a>
-      <a href='/docs'>Docs</a>
+      <a href='docs'>Docs</a>
       <a href='https://community.gazebosim.org' title="Discussion forum">Community</a>
       <a class="moreButton" role="button" [matMenuTriggerFor]="moreMenu">More</a>
       <mat-menu #moreMenu="matMenu">
@@ -37,7 +37,7 @@
   <mat-menu x-position="before" #menu="matMenu">
     <button mat-menu-item routerLink="/about">About</button>
     <button mat-menu-item routerLink="/features">Features</button>
-    <a mat-menu-item href='/docs'>Docs</a>
+    <a mat-menu-item href='docs'>Docs</a>
     <a mat-menu-item href='https://community.gazebosim.org' title="Discussion forum">Community</a>
     <a mat-menu-item href='https://answers.gazebosim.org' title="Technical help">Answers</a>
     <a mat-menu-item href="https://blog.openrobotics.org/tag/gazebo">Blog</a>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,7 +11,7 @@
       <div></div>
       <a routerLink='/features' routerLinkActive='active'>Features</a>
       <a routerLink='/showcase' routerLinkActive='active'>Showcase</a>
-      <a routerLink='/docs' routerLinkActive='active'>Docs</a>
+      <a href='/docs'>Docs</a>
       <a href='https://community.gazebosim.org' title="Discussion forum">Community</a>
       <a class="moreButton" role="button" [matMenuTriggerFor]="moreMenu">More</a>
       <mat-menu #moreMenu="matMenu">
@@ -37,7 +37,7 @@
   <mat-menu x-position="before" #menu="matMenu">
     <button mat-menu-item routerLink="/about">About</button>
     <button mat-menu-item routerLink="/features">Features</button>
-    <button mat-menu-item routerLink="/docs">Docs</button>
+    <a mat-menu-item href='/docs'>Docs</a>
     <a mat-menu-item href='https://community.gazebosim.org' title="Discussion forum">Community</a>
     <a mat-menu-item href='https://answers.gazebosim.org' title="Technical help">Answers</a>
     <a mat-menu-item href="https://blog.openrobotics.org/tag/gazebo">Blog</a>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,40 +23,27 @@ import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { AboutComponent } from './about';
-import { DocComponent,
-         DocsResolver } from './doc';
-import { DocService } from './doc/doc.service';
 import { ErrorInterceptor } from './error-interceptor';
 import { FeaturesComponent } from './features';
 import { HomeComponent } from './home';
-import { LibComponent } from './lib';
-import { LibsComponent } from './libs';
-import { LibsService } from './libs';
 import { MediaComponent } from './media';
 import { MaritimeComponent } from './projects/maritime';
 import { NotFoundComponent } from './not-found';
 import { OmniverseComponent } from './projects/omniverse';
 import { ShowcaseComponent } from './showcase';
 import { SupportComponent } from './support';
-import { ListedFilterPipe } from './doc/listed-filter.pipe';
-import { SafePipe } from './doc/safe.pipe';
 
 @NgModule({
   declarations: [
     AppComponent,
     AboutComponent,
-    DocComponent,
     FeaturesComponent,
-    LibComponent,
-    LibsComponent,
-    ListedFilterPipe,
     MediaComponent,
     HomeComponent,
     MaritimeComponent,
     NotFoundComponent,
     OmniverseComponent,
     SupportComponent,
-    SafePipe,
   ],
   imports: [
     AppRoutingModule,
@@ -93,10 +80,7 @@ import { SafePipe } from './doc/safe.pipe';
     ShowcaseComponent,
   ],
   providers: [
-    DocsResolver,
-    DocService,
     ErrorInterceptor,
-    LibsService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,31 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <!-- Taken from https://github.com/rafgraph/spa-github-pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // MIT License
+    // https://github.com/rafgraph/spa-github-pages
+    // This script checks to see if a redirect is present in the query string,
+    // converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function(l) {
+      if (l.search[1] === '/' ) {
+        var decoded = l.search.slice(1).split('&').map(function(s) {
+          return s.replace(/~and~/g, '&')
+        }).join('?');
+        window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+        );
+      }
+    }(window.location))
+  </script>
+  <!-- End Single Page Apps for GitHub Pages -->
   <style>
   body, html {
     background-color: #ffffff;

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,29 @@
   <!-- Taken from https://github.com/rafgraph/spa-github-pages -->
   <script type="text/javascript">
     // Single Page Apps for GitHub Pages
-    // MIT License
+    //
+    // The MIT License (MIT)
+    //
+    // Copyright (c) 2016 Rafael Pedicini
+    //
+    // Permission is hereby granted, free of charge, to any person obtaining a copy
+    // of this software and associated documentation files (the "Software"), to deal
+    // in the Software without restriction, including without limitation the rights
+    // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    // copies of the Software, and to permit persons to whom the Software is
+    // furnished to do so, subject to the following conditions:
+    //
+    // The above copyright notice and this permission notice shall be included in all
+    // copies or substantial portions of the Software.
+    //
+    // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    // SOFTWARE.
+    //
     // https://github.com/rafgraph/spa-github-pages
     // This script checks to see if a redirect is present in the query string,
     // converts it back into the correct url and adds it to the


### PR DESCRIPTION
This is in support of https://github.com/gazebosim/docs/pull/441 which is part of https://github.com/gazebosim/docs/issues/412. Based on https://github.com/rafgraph/spa-github-pages, this makes it possible to deploy the frontend (this repo) on Github Pages. This PR also removes the `/docs`, `/libs` and `/lib` routes which are to be handled by the statically generated pages in https://github.com/gazebosim/docs/pull/441. We could remove all the code that handles those routes, but I opted for a smaller PR for now and do the removal in a follow up PR.

To test locally,
```
npm install
npm run build
npm install http-server
http-server dist
```

Open the URL printed out by `http-server` and navigate to `/features`. This should work. Now refresh the page or go to the `/features` page by typing the full URL. This is what's fixed by this PR and should also work.