### PR TITLE
Fix broken links to routes that don't exist anymore

### DIFF
--- a/src/app/features/features.component.html
+++ b/src/app/features/features.component.html
@@ -23,6 +23,8 @@
     <aside fxFlex="1 auto"></aside>
   </div>
   <div style="padding: 20px;" fxLayoutAlign="center">
-    <button mat-raised-button color='primary' routerLink='/docs'>Get Started</button>
+    <a href='/docs'>
+      <button mat-raised-button color='primary'>Get Started</button>
+    </a>
   </div>
 </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -20,7 +20,7 @@
       rich suite of tools, libraries, and cloud services.
       </p>
 
-      <a mat-raised-button color="primary" routerLink='/docs/all/getstarted'>Get Started</a>
+      <a mat-raised-button color="primary" href='/docs/all/getstarted'>Get Started</a>
       <a mat-button color="primary" routerLink='/features'>Learn More</a>
     </div>
   </div>
@@ -51,7 +51,7 @@
   fast on your new physical designs in realistic environments with high
   fidelity sensors streams. Test control strategies in safety, and take
   advantage of simulation in continuous integration tests.  </p>
-      <a mat-raised-button color="primary" routerLink='/docs'>Learn More</a>
+      <a mat-raised-button color="primary" href='/docs'>Learn More</a>
     </div>
   </div>
 
@@ -130,7 +130,7 @@
         <div class='card-description'>
           Advanced robot simulator for research, design, and development.
         </div>
-        <a mat-button routerLink="/libs/gazebo" class='card-action'>Learn More</a>
+        <a mat-button href="/libs/gazebo" class='card-action'>Learn More</a>
       </div>
     </div>
 
@@ -141,7 +141,7 @@
         <div class='card-description'>
           Distributed asynchronous message passing based.
         </div>
-        <a mat-button routerLink="/libs/transport" class='card-action'>Learn More</a>
+        <a mat-button href="/libs/transport" class='card-action'>Learn More</a>
       </div>
     </div>
 
@@ -152,7 +152,7 @@
         <div class='card-description'>
           Extensive set of sensor and noise models.
         </div>
-        <a mat-button routerLink="/libs/sensors" class='card-action'>Learn More</a>
+        <a mat-button href="/libs/sensors" class='card-action'>Learn More</a>
       </div>
     </div>
 
@@ -163,7 +163,7 @@
         <div class='card-description'>
           A plugin-based interface to physics engines.
         </div>
-        <a mat-button routerLink="/libs/physics" class='card-action'>Learn More</a>
+        <a mat-button href="/libs/physics" class='card-action'>Learn More</a>
       </div>
     </div>
 
@@ -174,14 +174,14 @@
         <div class='card-description'>
         A plugin based interface to rendering engines.
         </div>
-        <a mat-button routerLink="/libs/rendering" class='card-action'>Learn More</a>
+        <a mat-button href="/libs/rendering" class='card-action'>Learn More</a>
       </div>
     </div>
 
     <div class="card">
       <div fxLayout="column" fxLayoutAlign='space-around center' fxFill>
         <div class='card-description'>
-          <a mat-button routerLink="/libs" class='card-action last'>All Libraries</a>
+          <a mat-button href="/libs" class='card-action last'>All Libraries</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This changes all `routerLink` type links to regular `a` links since the `/docs` and `/libs` routes longer exist and are handled by https://github.com/gazebosim/docs